### PR TITLE
Fix-Responsive-Issue

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -810,7 +810,7 @@ body {
 
 /* ====== MOBILE RESPONSIVENESS ====== */
 
-@media (max-width: 768px) {
+@media (max-width: 920px) {
     .container {
         height: 500px;
     }
@@ -865,6 +865,7 @@ body {
         right: 20px;
         padding: 10px;
         font-size: 12px;
+        margin-top:50px;
     }
 }
 
@@ -917,8 +918,8 @@ body {
         position: relative;
         top: auto;
         right: auto;
-        margin: 20px auto;
         width: 80%;
+        margin:50px auto;
     }
 
     .astronaut-orbit {


### PR DESCRIPTION
This PR belongs to the issue #16.
Changes made:

<> In the first media query
->The issue begins at 920px width, so updated the breakpoint to @media (max-width: 920px).
->Added margin-top: 50px; to prevent the stats section from colliding with the heading and subheading.

 In the second media query
->Removed the old margin property.
->Added a new property margin: 50px auto; for better alignment and spacing.